### PR TITLE
Moves deletion after auth check

### DIFF
--- a/client/pages/api/events/delete.ts
+++ b/client/pages/api/events/delete.ts
@@ -10,9 +10,6 @@ export default async function deleteEvent(req: NextApiRequest, res: NextApiRespo
   const id = JSON.parse(req.body).id;
   const host = JSON.parse(req.body).host;
 
-  const db = new DatabaseService();
-  const result = await db.deleteEvent(id);
-
   const auth = new AuthService()
   const authedUser = await auth.verify()
   if ( !authedUser ) {
@@ -24,6 +21,9 @@ export default async function deleteEvent(req: NextApiRequest, res: NextApiRespo
     res.status(403).send({ error: "User can only delete events that they host themselves" });
     return;
   }
+
+  const db = new DatabaseService();
+  const result = await db.deleteEvent(id);
 
   if(result.acknowledged && result.deletedCount === 1) {
     res.status(200).send({ message: "Event deleted successfully" });


### PR DESCRIPTION
Simply moves the deletion of the event to after the auth check.